### PR TITLE
PhantomJS for everybody - closes #24 and #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ At the moment, `browser-launcher2` supports following browsers on Windows, Unix 
 - IE (Windows only)
 - Opera
 - Safari
-- PhantomJS (Linux and OS X only)
+- PhantomJS
 
 ## Install
 

--- a/example/launch.js
+++ b/example/launch.js
@@ -5,7 +5,7 @@ launcher( function( err, launch ) {
 		return console.error( err );
 	}
 
-	launch( 'http://cksource.com/', process.env.BROWSER || 'chrome', function( err, instance ) {
+	launch( process.env.URL || 'http://cksource.com/', process.env.BROWSER || 'chrome', function( err, instance ) {
 		if ( err ) {
 			return console.error( err );
 		}

--- a/lib/detect.js
+++ b/lib/detect.js
@@ -1,6 +1,8 @@
 var spawn = require( 'child_process' ).spawn,
 	winDetect = require( 'win-detect-browsers' ),
 	darwin = require( './darwin' ),
+	path = require( 'path' ),
+	phantomjs = require( 'phantomjs' ),
 	extend = require( 'lodash' ).extend,
 	browsers = {
 		'google-chrome': {
@@ -45,28 +47,45 @@ var spawn = require( 'child_process' ).spawn,
 			image: 'opera.exe',
 			profile: true
 		}
-	},
-	winDetectMap = {
-		chrome: 'google-chrome',
-		chromium: 'chromium-browser',
-		ff: 'firefox',
-		phantom: 'phantomjs',
-		safari: 'safari',
-		ie: 'ie',
-		opera: 'opera'
 	};
+
+// extracted from karma-phantomjs-launcer (license MIT)
+// https://github.com/karma-runner/karma-phantomjs-launcher/blob/master/index.js
+function getPhatomjsCmd() {
+	// If the path we're given by phantomjs is to a .cmd, it is pointing to a global copy.
+	// Using the cmd as the process to execute causes problems cleaning up the processes
+	// so we walk from the cmd to the phantomjs.exe and use that instead.
+
+	var phantomSource = phantomjs.path;
+
+	if ( path.extname(phantomSource).toLowerCase() === '.cmd' ) {
+		return path.join(path.dirname( phantomSource ), '//node_modules//phantomjs//lib//phantom//phantomjs.exe');
+	}
+
+	return phantomSource;
+}
 
 function checkWindows( callback ) {
 	winDetect( function( found ) {
 		var available = found.map( function( browser ) {
-			var br = browsers[ winDetectMap[ browser.name ] ];
+			var br = browsers[ browserName ],
+			browserName = (browser.name === 'chrome') ? 'google-chrome' : browser.name;
 
 			return extend( {}, {
-				name: browser.name,
+				name: browserName,
 				command: browser.path,
 				version: browser.version
 			}, br || {} );
 		} );
+
+		available = available.filter( function( browser ) {
+			return ( !/phantom/ig.test( browser.name ) );
+		} );
+
+		available.push( extend( browsers.phantomjs, {
+			command: getPhatomjsCmd(),
+			version: phantomjs.version,
+		} ) );
 
 		callback( available );
 	} );

--- a/lib/detect.js
+++ b/lib/detect.js
@@ -122,6 +122,10 @@ function checkDarwin( name, callback ) {
 }
 
 function checkOthers( name, callback ) {
+	if (/phantom/ig.test(name)) {
+		return setImmediate(callback.bind(null, null, phantomjs.version, getPhatomjsCmd()));
+	}
+
 	var process = spawn( name, [ '--version' ] ),
 		re = browsers[ name ].re,
 		data = '';

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "mkdirp": "^0.5.0",
     "osenv": "^0.1.0",
     "plist": "^1.0.1",
-    "win-detect-browsers": "^0.0.2",
+    "win-detect-browsers": "~1.0.0",
     "uid": "0.0.2",
-    "rimraf": "~2.2.8"
+    "rimraf": "~2.2.8",
+    "phantomjs": "~1.9.12"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit does the following:

- removes name mapping for windows
- adds the `phanomjs` module to the dependencies, which will download the phantomjs binary - ready for usage
- it filters out all other `phantomjs` paths on Windows and only returns this one
- for non-Windows OS-es (function `checkOthers()` it checks to see if the name is `phantomjs` so that it doesn't need to run spawn to get its info)

I've checked this on both Windows and Linux and it works. I'm not at home atm, or else I would have checked it on OSX as well, but I'm almost sure it works fine there as well.

Let me know what you think.