### PR TITLE
Add support for launching phantomJS on OSX

### DIFF
--- a/lib/darwin/index.js
+++ b/lib/darwin/index.js
@@ -2,3 +2,4 @@ exports.safari = require( './safari' );
 exports.firefox = require( './firefox' );
 exports.chrome = exports[ 'google-chrome' ] = require( './chrome' );
 exports.opera = require( './opera' );
+exports.phantomjs = require( './phantomjs' );

--- a/lib/darwin/phantomjs.js
+++ b/lib/darwin/phantomjs.js
@@ -1,0 +1,29 @@
+var util = require( './util' );
+
+exports.path = getPath = function( callback ) {
+	util.findBin( 'phantomjs', function ( err, path ) {
+		if ( err ) {
+			callback( err, null );
+		} else if ( path ) {
+			callback( null, path );
+		} else {
+			callback( 'not installed' );
+		}
+	});
+};
+
+exports.version = getVersion = function ( callback ) {
+	getPath( function( err, path ) {
+		if ( err || !path ) {
+			callback( err, null );
+			return;
+		}
+		util.getBinVersion( 'phantomjs', function( err, version ) {
+			if ( err || !version ) {
+				callback( err, null );
+			} else {
+				callback( null, version );
+			}
+		});
+	});
+};

--- a/lib/darwin/util.js
+++ b/lib/darwin/util.js
@@ -32,6 +32,18 @@ exports.find = function( id, callback ) {
 	} );
 };
 
+exports.findBin = function (id, callback) {
+	exec("which " + id, function( err, path ) {
+		callback( err, path ? path.trim() : path );
+	});
+}
+
+exports.getBinVersion = function (id, callback) {
+	exec(id + " --version", function( err, version ) {
+		callback( err, version ? version.trim() : version );
+	});
+}
+
 exports.getInfoPath = function( p ) {
 	return path.join( p, 'Contents', 'Info.plist' );
 };


### PR DESCRIPTION
It looks like support for phantomJS on OSX got lost in the shuffle somewhere along the line. This pull request re-adds support for it.
