### PR TITLE
Bumped dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"mkdirp": "^0.5.0",
 		"osenv": "^0.1.0",
 		"plist": "^1.0.1",
-		"win-detect-browsers": "^1.0.1",
+		"win-detect-browsers": "^2.1.0",
 		"uid": "0.0.2",
 		"rimraf": "~2.2.8"
 	},


### PR DESCRIPTION
https://github.com/vweevers/win-detect-browsers#200

> 1.x callback style is still supported (at least until 3.0)

(This change helps fix a downstream toolchain SPDX license warning. I don't expect any functional change.)
